### PR TITLE
Allow nested paths in file names

### DIFF
--- a/lib/providers/filesystem/index.js
+++ b/lib/providers/filesystem/index.js
@@ -12,6 +12,7 @@ var g = require('strong-globalize')();
  */
 
 var fs = require('fs'),
+  fse = require('fs-extra'),
   path = require('path'),
   stream = require('stream'),
   async = require('async'),
@@ -58,6 +59,27 @@ function validateName(name, cb) {
       new Error(g.f('{{FileSystemProvider}}: Invalid name: %s', name))));
     if (!cb) {
       console.error(g.f('{{FileSystemProvider}}: Invalid name: %s', name));
+    }
+    return false;
+  }
+}
+
+function validateFilePath(filePath, cb) {
+  if (!filePath) {
+    cb && process.nextTick(cb.bind(null, new Error(g.f('Invalid name: %s', filePath))));
+    if (!cb) {
+      console.error(g.f('{{FileSystemProvider}}: Invalid name: %s', filePath));
+    }
+    return false;
+  }
+  var normalized = path.normalize(filePath);
+  if (normalized === filePath) {
+    return true;
+  } else {
+    cb && process.nextTick(cb.bind(null,
+      new Error(g.f('{{FileSystemProvider}}: Invalid name: %s', filePath))));
+    if (!cb) {
+      console.error(g.f('{{FileSystemProvider}}: Invalid name: %s', filePath));
     }
     return false;
   }
@@ -143,21 +165,7 @@ FileSystemProvider.prototype.destroyContainer = function(containerName, cb) {
   if (!validateName(containerName, cb)) return;
 
   var dir = path.join(this.root, containerName);
-  fs.readdir(dir, function(err, files) {
-    files = files || [];
-
-    var tasks = [];
-    files.forEach(function(f) {
-      tasks.push(fs.unlink.bind(fs, path.join(dir, f)));
-    });
-    async.parallel(tasks, function(err) {
-      if (err) {
-        cb && cb(err);
-      } else {
-        fs.rmdir(dir, cb);
-      }
-    });
-  });
+  fse.remove(dir, cb);
 };
 
 FileSystemProvider.prototype.getContainer = function(containerName, cb) {
@@ -185,7 +193,7 @@ FileSystemProvider.prototype.upload = function(options, cb) {
     );
   }
   var file = options.remote;
-  if (!validateName(file)) {
+  if (!validateFilePath(file)) {
     return writeStreamError(
       new Error(g.f('{{FileSystemProvider}}: Invalid name: %s', file)),
       cb
@@ -199,6 +207,7 @@ FileSystemProvider.prototype.upload = function(options, cb) {
   };
 
   try {
+    fse.ensureDirSync(path.dirname(filePath));
     //simulate the success event in filesystem provider
     //fixes: https://github.com/strongloop/loopback-component-storage/issues/58
     // & #23 & #67
@@ -221,7 +230,7 @@ FileSystemProvider.prototype.download = function(options, cb) {
     );
   }
   var file = options.remote;
-  if (!validateName(file, cb)) {
+  if (!validateFilePath(file, cb)) {
     return readStreamError(
       new Error(g.f('{{FileSystemProvider}}: Invalid name: %s', file)),
       cb
@@ -253,35 +262,35 @@ FileSystemProvider.prototype.getFiles = function(container, options, cb) {
   var self = this;
   if (!validateName(container, cb)) return;
   var dir = path.join(this.root, container);
-  fs.readdir(dir, function(err, entries) {
-    entries = entries || [];
-    var files = [];
-    var tasks = [];
-    entries.forEach(function(f) {
-      tasks.push(fs.stat.bind(fs, path.join(dir, f)));
+  var items = [];
+  var callback = cb;
+  fse.walk(dir)
+    .on('data', function(item) {
+      items.push(item);
+    })
+    .on('error', function(err) {
+      cb(err);
+      cb = function() {};
+    })
+    .on('end', function() {
+      var files = [];
+      items.forEach(function (item, index) {
+        var stat = item.stats;
+        if (stat.isFile()) {
+          var props = {container: container, name: path.relative(dir, item.path)};
+          populateMetadata(stat, props);
+          var file = new File(self, props);
+          files.push(file);
+        }
+      });
+      cb && cb(null, files);
     });
-    async.parallel(tasks, function(err, stats) {
-      if (err) {
-        cb && cb(err);
-      } else {
-        stats.forEach(function(stat, index) {
-          if (stat.isFile()) {
-            var props = {container: container, name: entries[index]};
-            populateMetadata(stat, props);
-            var file = new File(self, props);
-            files.push(file);
-          }
-        });
-        cb && cb(err, files);
-      }
-    });
-  });
 };
 
 FileSystemProvider.prototype.getFile = function(container, file, cb) {
   var self = this;
   if (!validateName(container, cb)) return;
-  if (!validateName(file, cb)) return;
+  if (!validateFilePath(file, cb)) return;
   var filePath = path.join(this.root, container, file);
   fs.stat(filePath, function(err, stat) {
     var f = null;
@@ -302,7 +311,7 @@ FileSystemProvider.prototype.getUrl = function(options) {
 
 FileSystemProvider.prototype.removeFile = function(container, file, cb) {
   if (!validateName(container, cb)) return;
-  if (!validateName(file, cb)) return;
+  if (!validateFilePath(file, cb)) return;
 
   var filePath = path.join(this.root, container, file);
   fs.unlink(filePath, cb);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "formidable": "^1.0.16",
+    "fs-extra": "^1.0.0",
     "pkgcloud": "^1.1.0",
     "strong-globalize": "^2.6.2"
   },


### PR DESCRIPTION
### Description

Allow `FileSystemProvider` to include nested identifiers to mimic behaviour with S3

Details:
- add fs-extra
- validate against path traversal ('a/../b.txt')
- create intermediate directories

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
